### PR TITLE
Wording clarifications related to appointing bodies and stream managers

### DIFF
--- a/draft-iab-rfcefdp-rfced-model.md
+++ b/draft-iab-rfcefdp-rfced-model.md
@@ -111,7 +111,7 @@ Center (RPC), under the ultimate authority of the IETF
 Administration Limited Liability Company (LLC) {{RFC8711}}.
 
 In this model, documents are produced and approved through
-multiple document streams. The stream manager for each stream
+multiple document streams. The stream approving body {{RFC8729}} for each stream
 is responsible for the content of that stream. The RFC Editor
 function is responsible for the packaging and distribution of
 the documents. As such, documents from these streams are
@@ -227,12 +227,12 @@ other appointed by the IAB. When the RSWG is formed, the chair
 appointed by the IESG shall serve for a term of one (1) year and
 the chair appointed by the IAB shall serve for a term of two (2)
 years; thereafter, chairs shall serve for a term of two (2)
-years, with no term limits on renewal. The appointing bodies shall
+years, with no term limits on renewal. The IESG and IAB shall
 determine their own processes for making these appointments.
 Community members who have concerns about the performance of an
-RSWG chair should direct their feedback to the relevant appointing
-body. Each appointing body shall have the power to remove its
-appointed chair at its discretion at any time, and to name a
+RSWG chair should direct their feedback to the group.
+The IESG and IAB shall have the power to remove their
+appointed chairs at their discretion at any time, and to name a
 replacement who shall serve the remainder of the original chair's
 term.
 
@@ -268,7 +268,7 @@ The voting members of the RSAB are as follows:
   delegate appointed by the ISE
 * The RFC Series Consulting Editor
 
-The appointing bodies shall determine their own processes for 
+The appointing bodies, i.e., the stream approval bodies, shall determine their own processes for 
 appointing RSAB members (note that processes related to the RSCE 
 are described in {{rsce}}). Each appointing body shall have the power to 
 remove its appointed RSAB member at its discretion at any time. 
@@ -581,7 +581,7 @@ The core responsibility of the RPC is continuous improvement regarding
 the implementation of RFC policies (including the dimensions of document
 quality, timeliness of production, and accessibility of results), while
 taking into account issues raised by the community through the RSWG and
-by the stream managers. More specifically, the RPC's responsibilities
+by the stream approving bodies. More specifically, the RPC's responsibilities
 include the following:
 
 1. Editing inputs from all RFC streams to comply with the RFC Style Guide.
@@ -593,7 +593,7 @@ include the following:
 
 4. Engaging in dialogue with authors, document shepherds, IANA, or
    stream-specific contacts (e.g., working group chairs and stream
-   managers) when clarification is needed.
+   approving bodies) when clarification is needed.
 
 5. Creating and preserving records of dialogue with document authors.
 
@@ -622,7 +622,7 @@ include the following:
     communication with the authors, document shepherds, IANA, or
     stream-specific contacts, and, if needed, with the RSAB and RSCE.
 
-16. Liaising with stream managers and other representatives of the
+16. Liaising with stream approving bodies and other representatives of the
     streams as needed.
 
 17. Announcing and providing on-line access to RFCs.
@@ -650,11 +650,11 @@ Director.
 However, if it is unclear whether an existing policy applies, or if the
 interpretation of an existing policy is unclear, the parties may need to
 consult with additional individuals or bodies (e.g., RSAB, IESG, IRSG, or
-stream manager) to help achieve a resolution. The following points are
+stream approving bodies) to help achieve a resolution. The following points are
 intended to provide more particular guidance.
 
 * If there is a conflict with a policy for a particular stream, the
-  RPC should consult with the relevant stream manager to help achieve a
+  RPC should consult with the relevant stream approving body to help achieve a
   resolution, if needed also conferring with a per-stream body such as the
   IESG or IRSG.
 
@@ -691,7 +691,7 @@ under the final authority of the IETF LLC.
 The IETF LLC develops the work definition (the Statement of Work)
 for the RPC and manages the vendor selection process.  The work
 definition is created within the IETF LLC budget and takes into
-account the needs of stream managers as well as community input.
+account the needs of stream approving bodies as well as community input.
 
 The process to select and contract for an RFC Production Center
 and other RFC-related services is as follows:
@@ -703,7 +703,7 @@ and other RFC-related services is as follows:
 *  The IETF LLC establishes a selection committee, which will
    consist of the IETF Executive Director and other
    members selected by the IETF LLC in consultation with the
-   stream managers. The committee shall select a chair from
+   stream aproving bodies. The committee shall select a chair from
    among its members.
 
 *  The selection committee selects the vendor, subject to the

--- a/draft-iab-rfcefdp-rfced-model.md
+++ b/draft-iab-rfcefdp-rfced-model.md
@@ -703,7 +703,7 @@ and other RFC-related services is as follows:
 *  The IETF LLC establishes a selection committee, which will
    consist of the IETF Executive Director and other
    members selected by the IETF LLC in consultation with the
-   stream aproving bodies. The committee shall select a chair from
+   stream approving bodies. The committee shall select a chair from
    among its members.
 
 *  The selection committee selects the vendor, subject to the


### PR DESCRIPTION
1. Use the term "stream approving body" instead of "stream manager",
   since the latter is ill-defined.

2. The term "appointing body" was used for both the IESG and IAB as appointers
   of RSWG chairs, and for the stream approval bodies as appointers of RSAB
   voting members. Change the former to explicitly talk about the IESG and IAB,
   and change the latter to clarify that "appointing body" means "stream
   approval body".